### PR TITLE
Only warn when `check_head_online` returns false

### DIFF
--- a/rga_etl/pc/scripts/rga_test.py
+++ b/rga_etl/pc/scripts/rga_test.py
@@ -1,3 +1,5 @@
+import warnings
+
 from rga_etl.databases.utils import init_session, init_instrument
 from rga_etl.pc.rga import init_rga
 
@@ -9,7 +11,7 @@ def main():
 
     rga = init_rga()
     if not rga.check_head_online():
-        raise RuntimeError("RGA head is not online.")
+        warnings.warn("RGA head is not online.")
     print(f"The ID of the RGA is {rga.check_id()}.\n")
     print("The status of the RGA is:")
     print(f"{rga.get_status()}.")


### PR DESCRIPTION
When using [OIKWAN USB Type C to RS232 DB9 Serial Port Adapter Cable, FTDI Chipset](https://www.amazon.com/dp/B08B5M1KBZ), the DSR is not transmitted by the Type-C, so this feature should not always raise an error.